### PR TITLE
fix: downgrade cpp-httplib to resolve build pipeline issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ endif ()
 FetchContent_Declare(
         httplib
         GIT_REPOSITORY https://github.com/yhirose/cpp-httplib.git
-        GIT_TAG 3af7f2c16147f3fbc6e4d717032daf505dc1652c
+        GIT_TAG cbca63f091ef1147ff57e90eb1ee5e558aa05d2c
 )
 FetchContent_Populate(httplib)
 


### PR DESCRIPTION
Failed build job: https://github.com/holalula/hbqj/actions/runs/14873835069/job/41767289656

Root cause:
```
[56/74] Building CXX object updater\CMakeFiles\updater.dir\main.cpp.obj
FAILED: updater/CMakeFiles/updater.dir/main.cpp.obj 
C:\PROGRA~1\MICROS~2\2022\ENTERP~1\VC\Tools\MSVC\1443~1.348\bin\Hostx64\x64\cl.exe  /nologo /TP -DUNICODE -D_UNICODE -ID:\a\hbqj\hbqj\include -ID:\a\hbqj\hbqj\build\include -ID:\a\hbqj\hbqj\build\_deps\httplib-src -external:I"C:\Program Files\OpenSSL\include" -external:W0 /DWIN32 /D_WINDOWS /GR /EHsc /O2 /Ob2 /DNDEBUG -std:c++latest -MD /permissive- /W3 /showIncludes /Foupdater\CMakeFiles\updater.dir\main.cpp.obj /Fdupdater\CMakeFiles\updater.dir\ /FS -c D:\a\hbqj\hbqj\updater\main.cpp
D:\a\hbqj\hbqj\build\_deps\httplib-src\httplib.h(308): fatal error C1189: #error:  Sorry, OpenSSL versions prior to 3.0.0 are not supported
```